### PR TITLE
Add automatic package discovery to composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,12 @@
   },
   "config": {
     "sort-packages": true
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Intouch\\LaravelAwsLambda\\LambdaServiceProvider"
+      ]
+    }
   }
 }


### PR DESCRIPTION
In the README file is states:

...On versions of Laravel less than 5.5, you'll want to register the service provider. Add Intouch\LaravelAwsLambda\LambdaServiceProvider::class, to the providers array in config/app.php.

But as things stand, this is still required in versions 5.5 and above. To enable package auto-discovery in Laravel 5.5 and above, it is required to add an extra section to composer.json so that Laravel can discover and add the service provider to bootstrap/cache/services.php.

This pull request adds the necessary config to composer.json which I have tested locally.

BTW, thanks for your work on this package, this is exactly what i needed.